### PR TITLE
Added projects layout

### DIFF
--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -6,17 +6,17 @@ layout: single
     <a href="{{ page.web }}">Μάθετε περισσότερα</a>
 {% endif %}
 
-{% assign p = 'Partners' %}
 
+<h2>{{ 'Συνεργαζόμενοι Φορείς' }}</h2>
 {% if page.partners %}
-  {% capture page_interests %}{% for interest in page.partners %}{{ interest | downcase }}#{{ interest }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
-  {% assign interest_hashes = (page_interests | split: ',' | sort:0) %}
-  <p class="page__taxonomy">
-    {% for hash in interest_hashes %}
-      {% assign keyValue = hash | split: '#' %}
-      {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
-      <a href="{{ interest | url_encode | prepend: 'https://www.google.gr/search?q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
-    {% endfor %}
-    </span>
-  </p>
+    {% capture page_interests %}{% for interest in page.partners %}{{ interest | downcase }}#{{ interest }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+    {% assign interest_hashes = (page_interests | split: ',' | sort:0) %}
+    <p class="page__taxonomy">
+        {% for hash in interest_hashes %}
+            {% assign keyValue = hash | split: '#' %}
+            {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
+            <a href="{{ interest | url_encode | prepend: 'https://www.google.gr/search?q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+        {% endfor %}
+        </span>
+    </p>
 {% endif %}

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -4,9 +4,7 @@ layout: single
 {{ content }}
 
 {% assign p = 'Partners' %}
-
 <h2>{{ p }}</h2>
-
 {% if page.partners %}
     {% capture page_interests %}{% for interest in page.partners %}{{ interest | downcase }}#{{ interest }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
     {% assign interest_hashes = (page_interests | split: ',' | sort:0) %}
@@ -21,11 +19,15 @@ layout: single
 {% endif %}
 
 <h2>{{ p }}</h2>
-
-<span itemprop="keywords">
-    {% if page.partners %}
+{% if page.partners %}
+    <span itemprop="keywords">
         {% for partner in page.partners %}
-            <a href="" class="page__taxonomy-item" rel="tag">{{ partner.title }}</a>
+            <a href="" class="page__taxonomy-item" rel="tag">{{ partner }}</a>
         {% endfor %}
-    {% endif %}
-</span>
+    </span>
+{% endif %}
+
+
+{% if page.web %}
+    <a href="{{ page.web }}">Μάθετε περισσότερα</a>
+{% endif %}

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -20,12 +20,3 @@ layout: single
         </span>
     </p>  
 {% endif %}
-
-<h2>{{ p }}</h2>
-{% if page.partners %}
-    <span itemprop="keywords">
-        {% for partner in page.partners %}
-            <div class="page__taxonomy-item" rel="tag">{{ partner }}</div>
-        {% endfor %}
-    </span>
-{% endif %}

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -15,7 +15,7 @@ layout: single
         {% for hash in interest_hashes %}
             {% assign keyValue = hash | split: '#' %}
             {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
-            <a href="{{ interest | url_encode | prepend: 'https://google.gr/scholar?hl=en&as_sdt=0%2C5&q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+            <a href="{{ interest | url_encode | prepend: 'https://www.google.gr/search?q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
         {% endfor %}
         </span>
     </p>  

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -1,0 +1,7 @@
+---
+layout: single
+---
+{{ page.title }}
+{{ page.excerpt }}
+
+{{ content }}

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -22,7 +22,7 @@ layout: single
 {% if page.partners %}
     <span itemprop="keywords">
         {% for partner in page.partners %}
-            <a href="" class="page__taxonomy-item" rel="tag">{{ partner }}</a>
+            <div class="page__taxonomy-item" rel="tag">{{ partner }}</div>
         {% endfor %}
     </span>
 {% endif %}

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -1,7 +1,22 @@
 ---
 layout: single
 ---
-{{ page.title }}
-{{ page.excerpt }}
+
+{% assign p = 'Partners' %}
+
+<h2>{{ p }}</h2>
+
+{% if page.partners %}
+  {% capture page_interests %}{% for interest in page.partners %}{{ interest | downcase }}#{{ interest }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+  {% assign interest_hashes = (page_interests | split: ',' | sort:0) %}
+  <p class="page__taxonomy">
+    {% for hash in interest_hashes %}
+      {% assign keyValue = hash | split: '#' %}
+      {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
+      <a href="{{ interest | url_encode | prepend: 'https://scholar.google.gr/scholar?hl=en&as_sdt=0%2C5&q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+    {% endfor %}
+    </span>
+  </p>
+{% endif %}
 
 {{ content }}

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -2,6 +2,9 @@
 layout: single
 ---
 {{ content }}
+{% if page.web %}
+    <a href="{{ page.web }}">Μάθετε περισσότερα</a>
+{% endif %}
 
 {% assign p = 'Partners' %}
 <h2>{{ p }}</h2>
@@ -12,7 +15,7 @@ layout: single
         {% for hash in interest_hashes %}
             {% assign keyValue = hash | split: '#' %}
             {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
-            <a href="{{ interest | url_encode | prepend: 'https://scholar.google.gr/scholar?hl=en&as_sdt=0%2C5&q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+            <a href="{{ interest | url_encode | prepend: 'https://google.gr/scholar?hl=en&as_sdt=0%2C5&q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
         {% endfor %}
         </span>
     </p>  
@@ -25,9 +28,4 @@ layout: single
             <div class="page__taxonomy-item" rel="tag">{{ partner }}</div>
         {% endfor %}
     </span>
-{% endif %}
-
-
-{% if page.web %}
-    <a href="{{ page.web }}">Μάθετε περισσότερα</a>
 {% endif %}

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -7,16 +7,16 @@ layout: single
 {% endif %}
 
 {% assign p = 'Partners' %}
-<h2>{{ p }}</h2>
+
 {% if page.partners %}
-    {% capture page_interests %}{% for interest in page.partners %}{{ interest | downcase }}#{{ interest }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
-    {% assign interest_hashes = (page_interests | split: ',' | sort:0) %}
-    <p class="page__taxonomy">
-        {% for hash in interest_hashes %}
-            {% assign keyValue = hash | split: '#' %}
-            {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
-            <a href="{{ interest | url_encode | prepend: 'https://www.google.gr/search?q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
-        {% endfor %}
-        </span>
-    </p>  
+  {% capture page_interests %}{% for interest in page.partners %}{{ interest | downcase }}#{{ interest }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+  {% assign interest_hashes = (page_interests | split: ',' | sort:0) %}
+  <p class="page__taxonomy">
+    {% for hash in interest_hashes %}
+      {% assign keyValue = hash | split: '#' %}
+      {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
+      <a href="{{ interest | url_encode | prepend: 'https://www.google.gr/search?q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+    {% endfor %}
+    </span>
+  </p>
 {% endif %}

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -20,10 +20,12 @@ layout: single
     </p>  
 {% endif %}
 
+<h2>{{ p }}</h2>
+
 <span itemprop="keywords">
     {% for project in site.projects %}
         {% for partner in project.partners %}
-            <a href="{{ partner.url | absolute_url }}" class="page__taxonomy-item" rel="tag">{{ partner }}</a>
+            <a href="" class="page__taxonomy-item" rel="tag">{{ partner }}</a>
         {% endfor %}
     {% endfor %}
 </span>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -1,22 +1,29 @@
 ---
 layout: single
 ---
+{{ content }}
 
 {% assign p = 'Partners' %}
 
 <h2>{{ p }}</h2>
 
 {% if page.partners %}
-  {% capture page_interests %}{% for interest in page.partners %}{{ interest | downcase }}#{{ interest }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
-  {% assign interest_hashes = (page_interests | split: ',' | sort:0) %}
-  <p class="page__taxonomy">
-    {% for hash in interest_hashes %}
-      {% assign keyValue = hash | split: '#' %}
-      {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
-      <a href="{{ interest | url_encode | prepend: 'https://scholar.google.gr/scholar?hl=en&as_sdt=0%2C5&q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
-    {% endfor %}
-    </span>
-  </p>
+    {% capture page_interests %}{% for interest in page.partners %}{{ interest | downcase }}#{{ interest }}{% unless forloop.last %},{% endunless %}{% endfor %}{% endcapture %}
+    {% assign interest_hashes = (page_interests | split: ',' | sort:0) %}
+    <p class="page__taxonomy">
+        {% for hash in interest_hashes %}
+            {% assign keyValue = hash | split: '#' %}
+            {% capture interest %}{{ keyValue[1] | strip_newlines }}{% endcapture %}
+            <a href="{{ interest | url_encode | prepend: 'https://scholar.google.gr/scholar?hl=en&as_sdt=0%2C5&q=' }}" class="page__taxonomy-item" rel="tag">{{ interest }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+        {% endfor %}
+        </span>
+    </p>  
 {% endif %}
 
-{{ content }}
+<span itemprop="keywords">
+    {% for project in site.projects %}
+        {% for partner in project.partners %}
+            <a href="{{ partner.url | absolute_url }}" class="page__taxonomy-item" rel="tag">{{ partner }}</a>
+        {% endfor %}
+    {% endfor %}
+</span>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -23,9 +23,9 @@ layout: single
 <h2>{{ p }}</h2>
 
 <span itemprop="keywords">
-    {% for project in site.projects %}
-        {% for partner in project.partners %}
+    {% if page.partners %}
+        {% for partner in page.partners %}
             <a href="" class="page__taxonomy-item" rel="tag">{{ partner }}</a>
         {% endfor %}
-    {% endfor %}
+    {% endif %}
 </span>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -25,7 +25,7 @@ layout: single
 <span itemprop="keywords">
     {% if page.partners %}
         {% for partner in page.partners %}
-            <a href="" class="page__taxonomy-item" rel="tag">{{ partner }}</a>
+            <a href="" class="page__taxonomy-item" rel="tag">{{ partner.title }}</a>
         {% endfor %}
     {% endif %}
 </span>


### PR DESCRIPTION
# Projects layout
Έφτιαξα ένα νέο layout ([_layouts/projects.html](https://github.com/jimDragon/minimal-ionio/blob/projects-layout/_layouts/projects.html)) το οποίο προβάλει όλα front matter variables που έχουν τα projects τα οποία στο παρελθόν ήταν σαν να μην υπήρχαν.

 **Αυτό το layout χρησιμοποιείται στο [pull request](https://github.com/ioniodi/site-gr/pull/85) μου για το site-gr και είναι απαραίτητο για την σωστή ενσωμάτωση του** 

## Design
- Προστέθηκε το κουμπί/σύνδεσμος "Μάθετε περισσότερα" το οποίο υλοποιεί το "web" front-matter variable του εκάστοτε project το οποίο παραπέμπει στην ιστοσελίδα του project.
_*Τα links χρειάζονται ενημέρωση_
- Προστέθηκε η ενότητα "Συνεργαζόμενοι Φορείς" στην οποία προβάλονται οι partners του project οι οποίοι βρίσκονται στο front matter του εκάστοτε project με την δομή:
```
---
partners:
 - partner 1
 - partner 2
 - partner ν
---
```
- Ο κάθε partner είναι ένα clickable link το οποίο κάνει αυτόματη αναζήτηση του partner στο google.

## Παρουσίαση αλλαγών
[Live Demo](https://nervous-franklin-0ffe98.netlify.com/projects/2017-08-10-big/)
