### PR TITLE
Sidebar for multiple course authors

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -1,6 +1,3 @@
-{% assign author = page.author | default: page.authors[0] | default: site.author %}
-{% assign author = site.data.authors[author] | default: author %}
-
 <div itemscope itemtype="http://schema.org/Person">
 
   {% if author.avatar %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,13 @@
 {% if page.author_profile or layout.author_profile or page.sidebar or page.book_sidebar %}
   <div class="sidebar sticky">
-  {% if page.author_profile or layout.author_profile %}{% include author-profile.html %}{% endif %}
+  {% if page.author_profile or layout.author_profile %}
+  {% assign authors = page.author | join: ',' | split: ',' %}
+
+  {% for curr_author in authors %}
+    {% assign author = site.data.authors[curr_author] | default: site.author %}
+    {% include author-profile.html %}
+  {% endfor %}
+  {% endif %}
   {% if page.book_sidebar %}{% include book-sidebar.html %}{% endif %}
   {% if page.sidebar %}
     {% for s in page.sidebar %}


### PR DESCRIPTION
### Σχετικό Issue
closes [site-gr/#121](https://github.com/ioniodi/site-gr/issues/121)

Demo: https://adoring-yonath-300689.netlify.app/courses/semantic-and-social-web/

### Προτεινόμενες Αλλαγές
-- Αλλαγή του sidebar ώστε να εμφανίζονται πολλαπλοί authors σε κάθε μάθημα.

### Σημειώσεις
1. Έκανα έναν έλεγχο μήπως χαλάει κάτι με τους πολλαπλούς authors, το μόνο που εντόπισα είναι στη σελίδα κάθε καθηγητή που αναγράφει τα μαθήματα του καθενός: για τα μαθήματα με πολλούς καθηγητές, αυτά δε συμπεριλαμβάνονται στη σελίδα τους. Θα μπορούσε ίσως να μπει ως ένα εύκολο issue στο site.
2. Στο site αυτή τη στιγμή κανένα μάθημα δεν έχει πολλαπλούς καθηγητές, οπότε η αλλαγή δεν εμφανίζεται κάπου. Θα μπορούσα να πειράξω ένα μάθημα (ίσως χωρίς PR για τόσο μικρή αλλαγή;) αν το θεωρεί κάποιος πρωτιμότερο.

