### PR TITLE
Fix content placement in courses layout

### DIFF
--- a/_layouts/courses.html
+++ b/_layouts/courses.html
@@ -5,10 +5,10 @@ layout: single
   <p>{{ page.excerpt }}</p>
 {% endif %}
 
+{{ content }}
+
 {% include table.html %}
 
 <a href="{{ page.uri }}" class="btn btn--success">E-class</a>
 
 {% include book.html %}
-
-{{ content }}


### PR DESCRIPTION
closes [#155](https://github.com/ioniodi/sitegr/issues/155)  στο [sitegr](https://github.com/ioniodi/sitegr)

Όσα μαθήματα είχαν κείμενο πέρα από την μεταβλητή `excerpt`, πλεον θα εμφανίζεται κατάλληλα ακριβώς πάνω από τον πίνακα και κάτω από την ίδια την εμφάνιση του excerpt.

**Αλλαγές**

- Μετακίνηση της μεταβλητής `{{ content }}` πάνω από το table και πριν την εμφάνιση του `{{ page.excerpt  }}`

**πριν**

![Screenshot_2021-03-12 Ελεύρη Επιλογή](https://user-images.githubusercontent.com/44473195/110914149-a971d800-831e-11eb-85ae-40d9154c0415.png)

**Μετά**
![Preview](https://user-images.githubusercontent.com/44473195/111343371-09041680-8684-11eb-992b-018c052a6bb8.png)

Live Preview: https://dimpram-ionio.netlify.app/courses/free-choice/