### PR TITLE
Fix non-working homepage link to study guide

### DIFF
--- a/_includes/video_background.html
+++ b/_includes/video_background.html
@@ -22,7 +22,7 @@
             <p class="page__meta"><i class="far fa-clock" aria-hidden="true"></i> {% include read-time.html %}</p>
           {% endif %}
           {% if page.header.cta_url %}
-            <p><a href="{{ cta_path }}" class="btn btn--light-outline btn--large">{{ page.header.cta_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
+            <p><a href="{{ page.header.cta_url }}" class="btn btn--light-outline btn--large">{{ page.header.cta_label | default: site.data.ui-text[site.locale].more_label | default: "Learn More" }}</a></p>
           {% endif %}
 
       


### PR DESCRIPTION
### Σχετικό Issue
closes ioniodi/sitegr#175

### Προτεινόμενες Αλλαγές
Διόρθωση κώδικα στο θέμα minimal-ionio για προσθήκη λειτουργικότητας στο κουμπί προς τον οδηγό σπουδών της αρχικής σελίδας. Το πρόβλημα βρισκόταν σε μια λάθος μεταβλητή liquid στο αρχείο video_background.html στο φάκελο _includes, με αποτέλεσμα ο σύνδεσμος να είναι κενός. Με την αλλαγή αυτή, ο σύνδεσμος δουλεύει κανονικά.

**Link στο Netlify:** https://compassionate-banach-64b6db.netlify.app

### Υπενθυμίσεις
- [x] Έχω ανοίξει από πριν issue για τον καλό συντονισμό του project, το οποίο έχει πάρει το πράσινο φως με την αντίστοιχη ετικέτα
- [x] Έχω ενημερώσει το issueNo παραπάνω με τον αριθμό του αντίστοιχου θέματος, ώστε να κλείσει αυτόματα με την αποδοχή αυτού του αιτήματος